### PR TITLE
Add wait groups and Admin API

### DIFF
--- a/examples/publish_event/main.go
+++ b/examples/publish_event/main.go
@@ -27,7 +27,12 @@ func main() {
 	}
 
 	// Publish
-	err := client.Publish(ctx, *topic, data)
+	_, err := client.Publish(
+		ctx,
+		*topic,
+		data,
+		sailhouse.WithScheduledTime(time.Now().Add(time.Hour*24*5)),
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/wait_group/main.go
+++ b/examples/wait_group/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/sailhouse/sdk-go/sailhouse"
+)
+
+// This example demonstrates how to use wait groups to publish multiple events
+// and wait for all of them to be processed as a group
+func main() {
+	// Get API key from environment
+	apiKey := os.Getenv("SAILHOUSE_API_KEY")
+	if apiKey == "" {
+		log.Fatal("SAILHOUSE_API_KEY environment variable is required")
+	}
+
+	// Create a new client
+	client := sailhouse.NewSailhouseClient(apiKey)
+
+	// Define the events to publish in the wait group
+	events := []sailhouse.WaitEvent{
+		{
+			Topic: "user-events",
+			Body: map[string]interface{}{
+				"type":    "user_created",
+				"user_id": "user-123",
+				"data": map[string]interface{}{
+					"name":  "Example User",
+					"email": "user@example.com",
+				},
+			},
+			Metadata: map[string]interface{}{
+				"source": "wait-group-example",
+			},
+		},
+		{
+			Topic: "notification-events",
+			Body: map[string]interface{}{
+				"type":    "email_notification",
+				"user_id": "user-123",
+				"data": map[string]interface{}{
+					"template": "welcome_email",
+					"to":       "user@example.com",
+				},
+			},
+			Metadata: map[string]interface{}{
+				"source": "wait-group-example",
+			},
+		},
+	}
+
+	// Define the wait group options
+	ttl := "5m" // 5 minutes TTL
+
+	// Create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Call Wait to create a wait group and publish all events
+	err := client.Wait(ctx, "onboarding-flow", events, sailhouse.WithTTL(ttl))
+	if err != nil {
+		log.Fatalf("Failed to wait for events: %v", err)
+	}
+
+	fmt.Println("Successfully published all events in the wait group")
+}

--- a/sailhouse/admin.go
+++ b/sailhouse/admin.go
@@ -1,0 +1,93 @@
+package sailhouse
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// RegisterResult represents the result of registering a push subscription
+type RegisterResult struct {
+	Outcome string `json:"outcome"` // "created", "updated", or "none"
+}
+
+// FilterOption represents a filter for subscription events
+type FilterOption struct {
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}
+
+// RegisterPushSubscriptionOptions contains optional parameters for registering a push subscription
+type RegisterPushSubscriptionOptions struct {
+	Filter *FilterOption
+}
+
+// AdminClient provides administrative functionality for Sailhouse
+type AdminClient struct {
+	client *SailhouseClient
+}
+
+// NewAdminClient creates a new AdminClient using the provided SailhouseClient
+func NewAdminClient(client *SailhouseClient) *AdminClient {
+	return &AdminClient{
+		client: client,
+	}
+}
+
+// RegisterPushSubscription registers a push subscription for a topic
+func (c *AdminClient) RegisterPushSubscription(
+	ctx context.Context,
+	topic string,
+	subscription string,
+	endpoint string,
+	options *RegisterPushSubscriptionOptions,
+) (*RegisterResult, error) {
+	url := fmt.Sprintf("%s/topics/%s/subscriptions/%s", BaseURL, topic, subscription)
+
+	// Build request body
+	requestBody := map[string]interface{}{
+		"type":     "push",
+		"endpoint": endpoint,
+	}
+
+	// Add filter if provided
+	if options != nil && options.Filter != nil {
+		requestBody["filter"] = options.Filter
+	}
+
+	// Marshal request body to JSON
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	// Create request
+	req, err := http.NewRequestWithContext(ctx, "PUT", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	resp, err := c.client.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	// Parse response
+	var result RegisterResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/sailhouse/event.go
+++ b/sailhouse/event.go
@@ -16,6 +16,14 @@ type EventResponse struct {
 	Data map[string]interface{} `json:"data"`
 }
 
+type PublishResponse struct {
+	ID string `json:"id"`
+}
+
+type WaitGroupInstanceResponse struct {
+	WaitGroupInstanceID string `json:"wait_group_instance_id"`
+}
+
 type Event struct {
 	ID           string                 `json:"id"`
 	Data         map[string]interface{} `json:"data"`


### PR DESCRIPTION
This pull request adds support for our in-development wait groups primitive, and our declarative Admin API allowing developers to define resources on Sailhouse from the codebase, as opposed to utilising the CLI or the UI.

Documentation to follow